### PR TITLE
Remove column number from YAMLException message

### DIFF
--- a/lib/js-yaml/mark.js
+++ b/lib/js-yaml/mark.js
@@ -59,7 +59,7 @@ Mark.prototype.toString = function toString(compact) {
     where += 'in "' + this.name + '" ';
   }
 
-  where += 'at line ' + (this.line + 1) + ', column ' + (this.column + 1);
+  where += 'at line ' + (this.line + 1);
 
   if (!compact) {
     snippet = this.getSnippet();


### PR DESCRIPTION
The column number in the YAMLException is buggy and not that helpful.
This change removes the column number from the exception message.
Related to https://github.com/AppliedIntuition/applied2/issues/79401 (Need to update hash in package.json to close out the issue)